### PR TITLE
Fix regex email validation

### DIFF
--- a/server/mongodb/models/User.js
+++ b/server/mongodb/models/User.js
@@ -14,7 +14,7 @@ const UserSchema = new Schema({
           return true;
         }
 
-        return /^[A-Za-z0-9._%+-]+@bgcma.org$/.test(email);
+        return /^[A-Za-z0-9._%+-]+@bgcma\.org$/.test(email);
       },
       message: "Please enter a valid email.",
     },


### PR DESCRIPTION
## Fixes regex email pattern

Changes the regex email pattern so that it only accepts @bgcma.org as a valid domain.

### How to Test

Tested using [regex101](https://regex101.com/).